### PR TITLE
Add SSL support using CL+SSL

### DIFF
--- a/birch.asd
+++ b/birch.asd
@@ -3,7 +3,7 @@
   :author "Joram Schrijver <i@joram.io>"
   :license "MIT"
   :version "1.0.1"
-  :depends-on (#:split-sequence #:usocket #:flexi-streams #:alexandria)
+  :depends-on (#:split-sequence #:usocket #:flexi-streams #:alexandria #:cl+ssl)
   :pathname "src"
   :components ((:file "replies")
                (:file "parse")


### PR DESCRIPTION
Does what it says on the tin, really: adds the `SSL` and `SSL-VERIFY` slots to `CONNECTION`. If `SSL` is set, will call `CL+SSL:MAKE-SSL-CLIENT-STREAM` on the TCP socket after creating it.