### PR TITLE
Make CL+SSL optional by adding :birch-no-ssl feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ Birch is built in Common Lisp on SBCL. It depends on:
 - [usocket](http://common-lisp.net/project/usocket/) (MIT)
 - [FLEXI-STREAMS](http://weitz.de/flexi-streams/) (BSD)
 - [Alexandria](http://common-lisp.net/project/alexandria/) (Public Domain)
+- [CL+SSL](https://github.com/cl-plus-ssl/cl-plus-ssl) (MIT)
 
 The tests also use [Prove](https://github.com/fukamachi/prove) (MIT).
+
+The CL+SSL requirement can be relaxed by adding `:birch-no-ssl` to `*features*`.
 
 ## Installation
 

--- a/birch.asd
+++ b/birch.asd
@@ -3,7 +3,7 @@
   :author "Joram Schrijver <i@joram.io>"
   :license "MIT"
   :version "1.0.1"
-  :depends-on (#:split-sequence #:usocket #:flexi-streams #:alexandria #:cl+ssl)
+  :depends-on (#:split-sequence #:usocket #:flexi-streams #:alexandria (:feature (:not :birch-no-ssl) #:cl+ssl))
   :pathname "src"
   :components ((:file "replies")
                (:file "parse")

--- a/src/connection.lisp
+++ b/src/connection.lisp
@@ -133,10 +133,11 @@ Whether to verify the SSL hostname.")
                                          :element-type '(unsigned-byte 8)))
          (socket-stream
            (if (ssl connection)
-               (cl+ssl:make-ssl-client-stream
-                (usocket:socket-stream socket)
-                :hostname (server-host connection)
-                :verify (ssl-verify connection))
+               #-birch-no-ssl (cl+ssl:make-ssl-client-stream
+                             (usocket:socket-stream socket)
+                             :hostname (server-host connection)
+                             :verify (ssl-verify connection))
+               #+birch-no-ssl (error "birch-no-ssl feature prohibits SSL support.")
                (usocket:socket-stream socket))))
     ;; Initialization
     (setf (%socket connection) socket


### PR DESCRIPTION
Thanks for the great library, I've been using it to build a MUD-like game environment and it's been solid :)

On NixOS loading OpenSSL can require extra work, and as I don't personally need SSL support here I've added a `:birch-no-ssl` feature to make CL+SSL optional.

This feature is named in keeping with other popular libraries, e.g. `:hunchentoot-no-ssl` and `:dexador-no-ssl`.

I've used `(error ...)` if a connection specifies SSL but CL+SSL isn't available, there might be a better way to handle this.